### PR TITLE
Fix typo in plotlib CMakeLists.txt related to 3D View Routines

### DIFF
--- a/plotlib/CMakeLists.txt
+++ b/plotlib/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 option(PRIMITIVE_3D_VIEW_ROUTINES
   "Add the primitive 3D-view routines" OFF)
 
-if(3D_VIEW_ROUTINES)
+if(PRIMITIVE_3D_VIEW_ROUTINES)
   set(PLT_SRCS ${PLT_SRCS} plt_3D.f)
 endif()
 


### PR DESCRIPTION
The option was named `PRIMITIVE_3D_VIEW_ROUTINES`, but the conditional was checking something called `3D_VIEW_ROUTINES`